### PR TITLE
📄 docs: publish llms.txt from the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,6 +15,7 @@ release = __version__
 copyright = f"2026-{datetime.now(tz=timezone.utc).year}, {company}"  # ruff:ignore[builtin-variable-shadowing]
 
 extensions = [
+    "sphinx_llm.txt",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.extlinks",
@@ -58,3 +60,5 @@ html_theme_options = {
     "sidebar_hide_name": True,
 }
 html_css_files = ["custom.css"]
+
+markdown_http_base = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ docs = [
   "furo>=2025.12.19",
   "sphinx>=9.1",
   "sphinx-autodoc-typehints>=3.6.3",
+  "sphinx-llm>=0.4.1",
   "sphinxcontrib-mermaid>=2",
   "sphinxcontrib-towncrier>=0.4",
   "towncrier>=25.8",


### PR DESCRIPTION
The [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) extension emits `llms.txt` ([llmstxt.org](https://llmstxt.org/)), `llms-full.txt`, and a markdown twin of each page during the HTML build; Read the Docs serves `llms.txt` from the docs domain root ([announcement](https://about.readthedocs.com/blog/2026/02/llms-txt-support/)). Plain markdown lets agents read the docs without rendering themed, JavaScript-dependent HTML. `markdown_http_base` keeps the sitemap links absolute so they resolve from the domain root.
