### PR TITLE
Avoid passing a non-Collection iterable to parametrize

### DIFF
--- a/tests/py_info/test_py_info.py
+++ b/tests/py_info/test_py_info.py
@@ -75,25 +75,19 @@ def test_bad_exe_py_info_no_raise(
 
 @pytest.mark.parametrize(
     "spec",
-    itertools.chain(
-        [sys.executable],
-        [
-            f"{impl}{'.'.join(str(i) for i in ver)}{'t' if CURRENT.free_threaded else ''}{arch}"
-            for impl, ver, arch in itertools.product(
-                (
-                    [CURRENT.implementation]
-                    + (["python"] if CURRENT.implementation == "CPython" else [])
-                    + (
-                        [CURRENT.implementation.lower()]
-                        if CURRENT.implementation != CURRENT.implementation.lower()
-                        else []
-                    )
-                ),
-                [sys.version_info[0 : i + 1] for i in range(3)],
-                ["", f"-{CURRENT.architecture}"],
-            )
-        ],
-    ),
+    [sys.executable]
+    + [
+        f"{impl}{'.'.join(str(i) for i in ver)}{'t' if CURRENT.free_threaded else ''}{arch}"
+        for impl, ver, arch in itertools.product(
+            (
+                [CURRENT.implementation]
+                + (["python"] if CURRENT.implementation == "CPython" else [])
+                + ([CURRENT.implementation.lower()] if CURRENT.implementation != CURRENT.implementation.lower() else [])
+            ),
+            [sys.version_info[0 : i + 1] for i in range(3)],
+            ["", f"-{CURRENT.architecture}"],
+        )
+    ],
 )
 def test_satisfy_py_info(spec: str) -> None:
     parsed_spec = PythonSpec.from_string_spec(spec)


### PR DESCRIPTION
This is deprecated since pytest 9.1; see https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators.

Using list concatenation (`+`) is simpler than wrapping the `itertools.chain(…)` in `list(…)`.

Avoids:

```
=============================== warnings summary ===============================
../../../../../usr/lib/python3.15/site-packages/_pytest/python.py:124
  /usr/lib/python3.15/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/py_info/test_py_info.py::test_satisfy_py_info, argvalues type: chain
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```